### PR TITLE
Fix login URL for teams with SSO

### DIFF
--- a/lib/slack.js
+++ b/lib/slack.js
@@ -20,6 +20,7 @@ module.exports = Slack;
  * Static variables
  */
 
+var loginFormPath = '/?no_sso=1';
 var emojiUploadFormPath = '/admin/emoji';
 var emojiUploadImagePath = '/customize/emoji';
 
@@ -65,7 +66,7 @@ function Slack(opts, debug) {
     var opts = this.opts;
     opts.jar = opts.jar || { _jar: { store: { idx: {} } } };
     var load = {
-      url: opts.url,
+      url: opts.url + loginFormPath,
       jar: opts.jar,
       method: 'GET'
     };
@@ -91,7 +92,7 @@ function Slack(opts, debug) {
   this.login = function *() {
     var opts = this.opts;
     var load = {
-      url: opts.url,
+      url: opts.url + loginFormPath,
       jar: opts.jar,
       method: 'POST',
       followAllRedirects: true,


### PR DESCRIPTION
Slack teams have the option to turn on login via Google auth, which results in the inital page not including a login form.  Adding the query-string parameter `no_sso` gets you to the actual login page.  I'm making the assumption that including that parameter does not break the loing for teams that _don't_ have Google SSO turned on.
