### PR TITLE
Add support for batch operation / configuration with environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,26 @@ emojis:
 
 Want to contribute? [Suggest an emoji pack](https://20p.typeform.com/to/xOFDyq)!
 
+## Batch use
+
+You can set the following environment variables instead of being prompted interactively for the parameters:
+
+* `SLACK_SUBDOMAIN`
+* `SLACK_EMAIL`
+* `SLACK_PASSWORD`
+* `SLACK_EMOJIPACK`
+
+For example:
+
+    SLACK_SUBDOMAIN=example SLACK_EMAIL=foobar@example.com SLACK_PASSWORD='secret-pw' SLACK_EMOJIPACK=packs/futurama.pack bin/emojipacks
+
+This is convenient when you want to import many emoji packs at once, you might use this to import ![:allthethings:](https://dujrsrsgsd3nh.cloudfront.net/img/emoticons/allthethings-1414024836@2x.png) at once for example:
+
+    export SLACK_SUBDOMAIN=example SLACK_EMAIL=foobar@example.com SLACK_PASSWORD='secret-pw'
+    for emoji in packs/*.yaml; do  SLACK_EMOJIPACK="$emoji" bin/emojipacks; done
+
+Please be cautious and know that if you use the environment variable configurations to drive the import on a multiuser system, that other people logged in could observe your Slack domain, email, and password while the script is running, as environment variables are not private. This does not matter so much on a single user system, such as your personal computer.
+
 ## Troubleshooting
 
 This script will essentially log into your Slack and then submit a `POST` request on the emoji upload form page. If you are seeing errors, make sure that:

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -19,10 +19,10 @@ var chalk = require('chalk');
 
 exports.start = function* () {
   var subdomain, email, password, pack, load, valid;
-  subdomain = yield ask('Slack subdomain: ', isSubdomain, 'Uh oh! The subdomain should be at least one letter!');
-  email = yield ask('Email address login: ', isEmail, 'Are you sure that is an email address? :)');
-  password = yield ask('Password: ', isPassword, 'A password (as defined by this script) needs to have at least one character (not including you).');
-  pack = yield ask('Path or URL of Emoji yaml file: ', isPath, 'Does the path to the yaml file look right? :)');
+  subdomain = yield ask('Slack subdomain: ', isSubdomain, 'Uh oh! The subdomain should be at least one letter!', 'SLACK_SUBDOMAIN');
+  email = yield ask('Email address login: ', isEmail, 'Are you sure that is an email address? :)', 'SLACK_EMAIL');
+  password = yield ask('Password: ', isPassword, 'A password (as defined by this script) needs to have at least one character (not including you).', 'SLACK_PASSWORD');
+  pack = yield ask('Path or URL of Emoji yaml file: ', isPath, 'Does the path to the yaml file look right? :)', 'SLACK_EMOJIPACK');
   load = {
     url: url(subdomain),
     email: email,
@@ -36,13 +36,14 @@ exports.start = function* () {
  * Prompt with validation.
  */
 
-function *ask(message, valid, error) {
+function *ask(message, valid, error, env) {
   var res;
   do {
-    if (message.toLowerCase().indexOf('password') >= 0) res = yield prompt.password(message);
+    if (process.env[env]) res = process.env[env]
+    else if (message.toLowerCase().indexOf('password') >= 0) res = yield prompt.password(message);
     else res = yield prompt(message);
     if (!valid(res)) err(error);
-  } while (!(valid(res)));
+  } while (!(valid(res)) && !process.env[env]);
   return res;
 }
 


### PR DESCRIPTION
This adds support for batch operation of emojipacks by looking at environment variables for configuration information.

You can set the following environment variables instead of being prompted interactively for the parameters:
- `SLACK_SUBDOMAIN`
- `SLACK_EMAIL`
- `SLACK_PASSWORD`
- `SLACK_EMOJIPACK`

For example:

```
SLACK_SUBDOMAIN=example SLACK_EMAIL=foobar@example.com SLACK_PASSWORD='secret-pw' SLACK_EMOJIPACK=packs/futurama.pack bin/emojipacks
```

This is convenient when you want to import many emoji packs at once, you might use this to import ![:allthethings:](https://dujrsrsgsd3nh.cloudfront.net/img/emoticons/allthethings-1414024836@2x.png) at once for example:

```
export SLACK_SUBDOMAIN=example SLACK_EMAIL=foobar@example.com SLACK_PASSWORD='secret-pw'
for emoji in packs/*.yaml; do  SLACK_EMOJIPACK="$emoji" bin/emojipacks; done
```
