### PR TITLE
Add "pokemon" list for original 151 Pokemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ emojis:
 - [pokemongo](https://raw.githubusercontent.com/lambtron/emojipacks/master/packs/pokemongo.yaml)
 - [nekoatsume](https://raw.githubusercontent.com/lambtron/emojipacks/master/packs/nekoatsume.yaml)
 - [octicons](https://raw.githubusercontent.com/lambtron/emojipacks/master/packs/octicons.yaml)
+- [pokemon](https://raw.githubusercontent.com/jaylynch/pokemoji/master/pokemon-by-name.yaml)
 
 ![](http://media1.giphy.com/media/68H7QjnqFOn2E/100.gif)
 


### PR DESCRIPTION
Adds a link in README.md to "pokemon", YAML from https://github.com/jaylynch/pokemoji which carries all 151 original Pokemon by name.
