### PR TITLE
Added the Pokemon Go Pokemon Emoji's links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ emojis:
 - [Slackmojis](https://raw.githubusercontent.com/lambtron/emojipacks/master/packs/slackmojis.yaml)
 - [parrotparty](https://raw.githubusercontent.com/lambtron/emojipacks/master/packs/parrotparty.yaml) ([Parrot](http://cultofthepartyparrot.com/) [Paint](http://cultofthepartyparrot.com/paint/))
 - [Finland](https://raw.githubusercontent.com/lambtron/emojipacks/master/packs/finland.yaml)
-- [pokemongo](https://raw.githubusercontent.com/lambtron/emojipacks/master/packs/pokemongo.yaml)
+- [pokemongo: items](https://raw.githubusercontent.com/lambtron/emojipacks/master/packs/pokemongo.yaml)
+- [Pokémon Go: Pokémon](https://raw.githubusercontent.com/Templarian/slack-emoji-pokemon/master/pokemon.yaml) ([Prefixed `pokemon-*`](https://raw.githubusercontent.com/Templarian/slack-emoji-pokemon/master/pokemon-prefix.yaml))
 - [nekoatsume](https://raw.githubusercontent.com/lambtron/emojipacks/master/packs/nekoatsume.yaml)
 - [octicons](https://raw.githubusercontent.com/lambtron/emojipacks/master/packs/octicons.yaml)
 


### PR DESCRIPTION
This includes the ones with and without the prefix. I'll be keeping this updated going forward as they add the rest of them. Right now it contains 152 (images extracted from the game and proportionally resized to look nicer in Slack).
