### PR TITLE
Allow emoji aliases to be created from emojipacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ emojis:
 - Image can't be larger than 128px in width or height
 - Image must be smaller than 64K in file size
 
+It is also possible to give multiple names to a single emoji using yaml such as:
+```yaml
+title: octicons
+emojis:
+  - name: pr
+    aliases:
+      - pullrequest
+      - mergerequest
+    src: https://i.imgur.com/rhwNxfc.png
+```
+
 
 ## Emoji packs
 

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -52,7 +52,14 @@ function Slack(opts, debug) {
     console.log('Getting emoji page');
     for (var i = 0; i < Object.keys(this.opts.emojis).length; i++) {
       var e = this.opts.emojis[i];
-      var uploadRes = yield this.upload(e.name, e.src);
+      if (e.src) {
+        var uploadRes = yield this.upload(e.name, e.src);
+      }
+      if (e.aliases) {
+        for (var n = 0; n < e.aliases.length; n++) {
+          yield this.alias(e.name, e.aliases[n]);
+        }
+      }
     }
     console.log('Uploaded emojis');
     return 'Success';
@@ -145,6 +152,28 @@ function Slack(opts, debug) {
       form.append('name', name);
       form.append('mode', 'data');
       form.append('img', req(emoji));
+    }.bind(this));
+  };
+
+  this.alias = function *(name, alias) {
+    console.log('Aliasing %s to %s', alias, name);
+    return new Promise(function(resolve, reject, notify) {
+      var opts = this.opts;
+      var r = req({
+        url: opts.url + emojiUploadImagePath,
+        method: 'POST',
+        jar: opts.jar,
+        followAllRedirects: true
+      }, function(err, res, body) {
+        if (err || !body) return reject(err);
+        resolve(body);
+      });
+      var form = r.form();
+      form.append('add', '1');
+      form.append('crumb', opts.uploadCrumb);
+      form.append('name', alias);
+      form.append('mode', 'alias');
+      form.append('alias', name);
     }.bind(this));
   };
 }

--- a/packs/octicons.yaml
+++ b/packs/octicons.yaml
@@ -1,16 +1,16 @@
 title: octicons
 emojis:
   - name: branch
-    src: http://i.imgur.com/2B16Phe.png
-  - name: bug
+    aliases:
+      - bug
     src: http://i.imgur.com/2B16Phe.png
   - name: commit
     src: https://i.imgur.com/UuAvkKE.png
   - name: compare
     src: https://i.imgur.com/fW9dOK8.png
   - name: fork
-    src: https://i.imgur.com/jzP6HET.png
-  - name: forked
+    aliases:
+      - forked
     src: https://i.imgur.com/jzP6HET.png
   - name: git
     src: https://i.imgur.com/5t3vu0G.png
@@ -21,22 +21,21 @@ emojis:
   - name: launch
     src: https://i.imgur.com/9uZJTNZ.png
   - name: merge
-    src: https://i.imgur.com/K4aI6sb.png
-  - name: merged
+    aliases:
+      - merged
     src: https://i.imgur.com/K4aI6sb.png
   - name: package
     src: http://i.imgur.com/fXl3uqe.png
   - name: pr
-    src: https://i.imgur.com/rhwNxfc.png
-  - name: pullrequest
-    src: https://i.imgur.com/rhwNxfc.png
-  - name: mergerequest
+    aliases:
+      - pullrequest
+      - mergerequest
     src: https://i.imgur.com/rhwNxfc.png
   - name: repository
     src: https://i.imgur.com/CD8EFDU.png
   - name: shipit
     src: https://i.imgur.com/jv3mw7d.png
   - name: tag
-    src: https://i.imgur.com/cBFKhdk.png
-  - name: version
+    aliases:
+      - version
     src: https://i.imgur.com/cBFKhdk.png


### PR DESCRIPTION
Slack permits emoji to be given aliases for one image.
This change introduces an aliases key to the emoji entry in the YAML to assign alternate names to the emoji on upload.

For example, the GitHub Octicons currently use multiple uploads instead of aliases for a number of icons, this allows them to be merged into one entry in the file:

``` diff
   - name: pr
-    src: https://i.imgur.com/rhwNxfc.png
-  - name: pullrequest
-    src: https://i.imgur.com/rhwNxfc.png
-  - name: mergerequest
+    aliases:
+      - pullrequest
+      - mergerequest
     src: https://i.imgur.com/rhwNxfc.png
```
