### PR TITLE
Added college football logos emojis for each school in the SEC

### DIFF
--- a/packs/secfootball.yaml
+++ b/packs/secfootball.yaml
@@ -1,0 +1,30 @@
+title: sec football
+emojis:
+  - name: florida
+    src: http://i.imgur.com/L3meMSF.png
+  - name: georgia
+    src: http://i.imgur.com/1ovs3Gk.png
+  - name: kentucky
+    src: http://i.imgur.com/wtUXhZi.png
+  - name: missouri
+    src: http://i.imgur.com/RU5ghT8.jpg
+  - name: south carolina
+    src: http://i.imgur.com/GRAvt1L.png
+  - name: tennessee
+    src: http://i.imgur.com/0cSEVqQ.gif
+  - name: vanderbilt
+    src: http://i.imgur.com/LLbt2JT.png
+  - name: alabama
+    src: http://i.imgur.com/K1kwMzv.png
+  - name: arkansas
+    src: http://i.imgur.com/VAt7kvk.png
+  - name: auburn
+    src: http://i.imgur.com/LyJ5BEn.png
+  - name: louisiana state
+    src: http://i.imgur.com/ddiOxAL.gif
+  - name: ole miss
+    src: http://i.imgur.com/ZXNDabh.png
+  - name: mississippi state
+    src: http://i.imgur.com/cQWeyTZ.png
+  - name: texas am
+    src: http://i.imgur.com/nQRHNrR.png


### PR DESCRIPTION
Added logos for:
- florida
- georgia
- kentucky
- missouri
- south carolina
- tennessee
- vanderbilt
- alabama
- arkansas
- auburn
- louisiana state
- ole miss
- mississippi state
- texas a&m
