### PR TITLE
Correct duplicate parrot

### DIFF
--- a/packs/parrotparty.yaml
+++ b/packs/parrotparty.yaml
@@ -48,7 +48,7 @@ emojis:
     src: http://cultofthepartyparrot.com/parrots/explodyparrot.gif
   - name: shufflepartyparrot
     src: http://cultofthepartyparrot.com/parrots/shufflepartyparrot.gif
-  - name: parrot
+  - name: icecreamparrot
     src: http://cultofthepartyparrot.com/parrots/ice-cream-parrot.gif
   - name: sassyparrot
     src: http://cultofthepartyparrot.com/parrots/sassyparrot.gif


### PR DESCRIPTION
Ice Cream Parrot had the name "parrot" which lead to it not being uploaded. Corrected so we can enjoy the full glory of the parrots.
