### PR TITLE
Load credentials from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ Password: *********
 Path or URL of Emoji yaml file: ./packs/futurama.yaml
 ```
 
+Or you can create a credentials file in your home directory: `~/.emojipacks.yaml`:
+
+```yaml
+subdomain: 20percentclub
+email: andyjiang@gmail.com
+```
+
+_Note that for security it will always ask for your password_
+
 Then, let it work its magic:
 
 ```bash

--- a/lib/creds.js
+++ b/lib/creds.js
@@ -10,7 +10,21 @@ var get = require('thunkify-wrap')(require('request').get);
 var yaml = require('js-yaml');
 var fs = require('fs');
 
-exports.get = function () {
+var userCredsFile = expandPath('~/.emojipacks.yaml');
+
+/**
+ * Check if there is a user credentials file
+ *
+ * @return {Boolean}
+ */
+exports.hasCredsFile = hasCredsFile;
+
+/**
+ * Load and get the credentials from the credentials user file
+ *
+ * @return {Object}
+ */
+exports.get = function() {
   var creds = loadCredentials();
   if (creds) return {
     subdomain: validate(creds.subdomain, isSubdomain, 'Uh oh! The subdomain should be at least one letter!'),
@@ -20,27 +34,34 @@ exports.get = function () {
 }
 
 /**
+ * Check if there is a user credentials file
+ *
+ * @return {Boolean}
+ */
+
+function hasCredsFile() {
+  return exists(userCredsFile);
+}
+
+/**
  * Load credentials YAML
  *
  * @return {Object}
  */
 
 function loadCredentials() {
-  var creds = getYaml("~/.emojipacks.yaml");
+  var creds = getYaml();
   if (creds) return yaml.safeLoad(creds);
 }
 
 /**
  * Get the yaml.
  *
- * @param {String} path
- *
  * @return {array}
  */
 
-function getYaml(path) {
-  path = expandPath(path);
-  if (exists(resolve(process.cwd(), path))) return fs.readFileSync(path, 'utf-8');
+function getYaml() {
+  if (hasCredsFile) return fs.readFileSync(userCredsFile, 'utf-8');
   return;
 }
 

--- a/lib/creds.js
+++ b/lib/creds.js
@@ -1,0 +1,86 @@
+var isSubdomain = require('./valid').subdomain;
+var isPassword = require('./valid').password;
+var isEmail = require('./valid').email;
+var isUri = require('valid-url').isUri;
+var resolve = require('path').resolve;
+var join = require('path').join;
+var exists = require('fs').existsSync;
+var chalk = require('chalk');
+var get = require('thunkify-wrap')(require('request').get);
+var yaml = require('js-yaml');
+var fs = require('fs');
+
+exports.get = function () {
+  var creds = loadCredentials();
+  if (creds) return {
+    subdomain: validate(creds.subdomain, isSubdomain, 'Uh oh! The subdomain should be at least one letter!'),
+    email: validate(creds.email, isEmail, `Are you sure that [${creds.email}] is an email address? :)`),
+    password: validate(creds.password, isPassword, 'A password (as defined by this script) needs to have at least one character (not including you).')
+  };
+}
+
+/**
+ * Load credentials YAML
+ *
+ * @return {Object}
+ */
+
+function loadCredentials() {
+  var creds = getYaml("~/.emojipacks.yaml");
+  if (creds) return yaml.safeLoad(creds);
+}
+
+/**
+ * Get the yaml.
+ *
+ * @param {String} path
+ *
+ * @return {array}
+ */
+
+function getYaml(path) {
+  path = expandPath(path);
+  if (exists(resolve(process.cwd(), path))) return fs.readFileSync(path, 'utf-8');
+  return;
+}
+
+/**
+ * Validates credentials
+ *
+ * @param {String} cred
+ * @param {Function} validates
+ * @param {String} error
+ *
+ * @return {String}
+ */
+
+function validate(cred, validates, error) {
+  if (!validates(cred)) {
+    err(chalk.red(error));
+    throw new Error(error);
+  }
+  return cred;
+}
+
+/**
+ * Expand ~ to home path
+ *
+ * @param {String} path
+ *
+ * @return {String}
+ */
+
+function expandPath(path) {
+  if (path[0] === '~') {
+    return join(process.env.HOME, path.slice(1));
+  }
+  return path;
+}
+
+/**
+ * Show error message.
+ */
+
+function err(message) {
+  console.log(chalk.red(message));
+}

--- a/lib/creds.js
+++ b/lib/creds.js
@@ -27,7 +27,7 @@ exports.hasCredsFile = hasCredsFile;
 exports.get = function() {
   var creds = loadCredentials();
   if (creds) return {
-    subdomain: validate(creds.subdomain, isSubdomain, 'Uh oh! The subdomain should be at least one letter!'),
+    url: validate(creds.subdomain, isSubdomain, 'Uh oh! The subdomain should be at least one letter!'),
     email: validate(creds.email, isEmail, `Are you sure that [${creds.email}] is an email address? :)`),
     password: validate(creds.password, isPassword, 'A password (as defined by this script) needs to have at least one character (not including you).')
   };

--- a/lib/creds.js
+++ b/lib/creds.js
@@ -28,8 +28,7 @@ exports.get = function() {
   var creds = loadCredentials();
   if (creds) return {
     url: validate(creds.subdomain, isSubdomain, 'Uh oh! The subdomain should be at least one letter!'),
-    email: validate(creds.email, isEmail, `Are you sure that [${creds.email}] is an email address? :)`),
-    password: validate(creds.password, isPassword, 'A password (as defined by this script) needs to have at least one character (not including you).')
+    email: validate(creds.email, isEmail, `Are you sure that [${creds.email}] is an email address? :)`)
   };
 }
 

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -11,7 +11,7 @@ var resolve = require('path').resolve;
 var exists = require('fs').existsSync;
 var prompt = require('co-prompt');
 var chalk = require('chalk');
-
+var creds = require('./creds.js');
 
 /**
  * Start.
@@ -19,16 +19,16 @@ var chalk = require('chalk');
 
 exports.start = function* () {
   var subdomain, email, password, pack, load, valid;
-  subdomain = yield ask('Slack subdomain: ', isSubdomain, 'Uh oh! The subdomain should be at least one letter!');
-  email = yield ask('Email address login: ', isEmail, 'Are you sure that is an email address? :)');
-  password = yield ask('Password: ', isPassword, 'A password (as defined by this script) needs to have at least one character (not including you).');
+
+  if (!creds.hasCredsFile()) {
+    subdomain = yield ask('Slack subdomain: ', isSubdomain, 'Uh oh! The subdomain should be at least one letter!');
+    email = yield ask('Email address login: ', isEmail, 'Are you sure that is an email address? :)');
+    password = yield ask('Password: ', isPassword, 'A password (as defined by this script) needs to have at least one character (not including you).');
+    creds = { url: subdomain, email, password };
+  }
   pack = yield ask('Path or URL of Emoji yaml file: ', isPath, 'Does the path to the yaml file look right? :)');
-  load = {
-    url: url(subdomain),
-    email: email,
-    password: password,
-    pack: pack
-  };
+  load = Object.assign({ pack }, creds.get());
+  load.url = url(load.url);
   return load;
 }
 

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -19,15 +19,14 @@ var creds = require('./creds.js');
 
 exports.start = function* () {
   var subdomain, email, password, pack, load, valid;
-
   if (!creds.hasCredsFile()) {
     subdomain = yield ask('Slack subdomain: ', isSubdomain, 'Uh oh! The subdomain should be at least one letter!');
     email = yield ask('Email address login: ', isEmail, 'Are you sure that is an email address? :)');
-    password = yield ask('Password: ', isPassword, 'A password (as defined by this script) needs to have at least one character (not including you).');
-    creds = { url: subdomain, email, password };
+    creds = { url: subdomain, email };
   }
+  password = yield ask('Password: ', isPassword, 'A password (as defined by this script) needs to have at least one character (not including you).');
   pack = yield ask('Path or URL of Emoji yaml file: ', isPath, 'Does the path to the yaml file look right? :)');
-  load = Object.assign({ pack }, creds.get());
+  load = Object.assign({ pack, password }, creds.get());
   load.url = url(load.url);
   return load;
 }


### PR DESCRIPTION
Add support for a credentials file, so the user doesn't have to keep typing the subdomain and email.
The credentials file should be in `~/.emojipacks.yaml`. If the file is not there, fall back to prompt the user.