### PR TITLE
Remove stray pry import

### DIFF
--- a/lib/slack.js
+++ b/lib/slack.js
@@ -11,7 +11,6 @@ var req = require('request');
 var fs = require('fs');
 var ask = require('./prompt').prompt_ask;
 var isPassword = require('./valid').password;
-var pry = require('pryjs')
 
 /**
  * Expose `Slack`.


### PR DESCRIPTION
This made the package unusable in some cases, as pryjs isn't a package dependency.