### PR TITLE
image-checker.py: Fix python 3 compatibility

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,3 +1,2 @@
 pillow
 pyyaml
-wget


### PR DESCRIPTION
Move from using wget library to direct calls to urllib, doesn't add too
much additional complexity to the code. Also handle HTTP errors as
script errors instead of terminating abnormally.

Fixes #104