### PR TITLE
Allow emoji aliases to be created from emojipacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,18 @@ emojis:
 - Image can't be larger than 128px in width or height
 - Image must be smaller than 64K in file size
 
+### Emoji Aliases
+It is possible to give multiple names to a single emoji using yaml such as:
+```yaml
+title: octicons
+emojis:
+  - name: pr
+    aliases:
+      - pullrequest
+      - mergerequest
+    src: https://i.imgur.com/rhwNxfc.png
+```
+
 
 ## Emoji packs
 

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -53,12 +53,22 @@ function Slack(opts, debug) {
     }
     console.log('Getting emoji page');
     var emojiList = '';
+    var aliasList = '';
     for (var i = 0; i < Object.keys(this.opts.emojis).length; i++) {
       var e = this.opts.emojis[i];
-      var uploadRes = yield this.upload(e.name, e.src);
-      emojiList += ' :' + e.name + ':';
+      if (e.src) {
+        var uploadRes = yield this.upload(e.name, e.src);
+        emojiList += ' :' + e.name + ':';
+      }
+      if (e.aliases) {
+        for (var n = 0; n < e.aliases.length; n++) {
+          yield this.alias(e.name, e.aliases[n]);
+          aliasList += ' :' + e.aliases[n] + ':';
+        }
+      }
     }
     console.log('Uploaded emojis:' + emojiList);
+    console.log('Uploaded emoji aliases:' + aliasList);
     return 'Success';
   };
 
@@ -176,6 +186,28 @@ function Slack(opts, debug) {
       form.append('name', name);
       form.append('mode', 'data');
       form.append('img', req(emoji));
+    }.bind(this));
+  };
+
+  this.alias = function *(name, alias) {
+    console.log('Aliasing %s to %s', alias, name);
+    return new Promise(function(resolve, reject, notify) {
+      var opts = this.opts;
+      var r = req({
+        url: opts.url + emojiUploadImagePath,
+        method: 'POST',
+        jar: opts.jar,
+        followAllRedirects: true
+      }, function(err, res, body) {
+        if (err || !body) return reject(err);
+        resolve(body);
+      });
+      var form = r.form();
+      form.append('add', '1');
+      form.append('crumb', opts.uploadCrumb);
+      form.append('name', alias);
+      form.append('mode', 'alias');
+      form.append('alias', name);
     }.bind(this));
   };
 }

--- a/packs/octicons.yaml
+++ b/packs/octicons.yaml
@@ -1,16 +1,16 @@
 title: octicons
 emojis:
   - name: branch
-    src: http://i.imgur.com/2B16Phe.png
-  - name: bug
+    aliases:
+      - bug
     src: http://i.imgur.com/2B16Phe.png
   - name: commit
     src: https://i.imgur.com/UuAvkKE.png
   - name: compare
     src: https://i.imgur.com/fW9dOK8.png
   - name: fork
-    src: https://i.imgur.com/jzP6HET.png
-  - name: forked
+    aliases:
+      - forked
     src: https://i.imgur.com/jzP6HET.png
   - name: git
     src: https://i.imgur.com/5t3vu0G.png
@@ -21,22 +21,21 @@ emojis:
   - name: launch
     src: https://i.imgur.com/9uZJTNZ.png
   - name: merge
-    src: https://i.imgur.com/K4aI6sb.png
-  - name: merged
+    aliases:
+      - merged
     src: https://i.imgur.com/K4aI6sb.png
   - name: package
     src: http://i.imgur.com/fXl3uqe.png
   - name: pr
-    src: https://i.imgur.com/rhwNxfc.png
-  - name: pullrequest
-    src: https://i.imgur.com/rhwNxfc.png
-  - name: mergerequest
+    aliases:
+      - pullrequest
+      - mergerequest
     src: https://i.imgur.com/rhwNxfc.png
   - name: repository
     src: https://i.imgur.com/CD8EFDU.png
   - name: shipit
     src: https://i.imgur.com/dPNghIL.png
   - name: tag
-    src: https://i.imgur.com/cBFKhdk.png
-  - name: version
+    aliases:
+      - version
     src: https://i.imgur.com/cBFKhdk.png

--- a/packs/slackmojis.yaml
+++ b/packs/slackmojis.yaml
@@ -196,6 +196,8 @@ emojis:
     name: doge2
   - src: http://emojis.slackmojis.com/emojis/images/1457563042/312/doge.png
     name: doge
+    aliases:
+    - doge3
   - src: http://emojis.slackmojis.com/emojis/images/1463602545/441/door_stop.png
     name: door_stop
   - src: http://emojis.slackmojis.com/emojis/images/1463602516/440/epic_win.png
@@ -692,8 +694,6 @@ emojis:
     name: disco_dance
   - src: http://emojis.slackmojis.com/emojis/images/1458327098/325/dna.png
     name: dna
-  - src: http://emojis.slackmojis.com/emojis/images/1457563042/312/doge.png
-    name: doge3
   - src: http://emojis.slackmojis.com/emojis/images/1450319448/68/domo.png
     name: domo
   - src: http://emojis.slackmojis.com/emojis/images/1454373223/284/donald_trump.png
@@ -1178,8 +1178,6 @@ emojis:
     name: terminator
   - src: http://emojis.slackmojis.com/emojis/images/1450663468/218/terrycrews.png
     name: terrycrews
-  - src: http://emojis.slackmojis.com/emojis/images/1459365617/335/tesla.jpg
-    name: tesla
   - src: http://emojis.slackmojis.com/emojis/images/1450319444/29/thankyou.gif
     name: thankyou
   - src: http://emojis.slackmojis.com/emojis/images/1466719485/583/thank_you.gif


### PR DESCRIPTION
Reopening #52 with refreshed patch. Might conflict with #105, but I'm happy to rebase against it again.

Aliases can be defined using a list of names under the aliases key of an
emoji definition. See the updated README.md for more details.

New errors added to image-checker.py:
* `Error: Emoji named ___ already defined elsewhere.`
  For when the emoji being tested has been defined as an emoji or alias
  already.
* `Error: Alias named ___ already defined elsewhere.`
  For when the alias being tested has been defined as an emoji or alias
  already.
* `Warning: ___ should be an alias for ___.`
  For when two emoji definitions share the same URL.

Existing emojipacks have been aliased and de-duplicated as appropriate.