### PR TITLE
Reenable emoji uploads for new api endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Logs
 logs
 *.log
+debug/
 
 # Runtime data
 pids
@@ -31,3 +32,6 @@ resized/
 
 # Ignore actual batchUpload.sh
 batchUpload.sh
+
+# OSX Garbage
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # Logs
 logs
 *.log
-debug/
 
 # Runtime data
 pids

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -23,8 +23,11 @@ module.exports = Slack;
  */
 
 var loginFormPath = '/?no_sso=1';
-var emojiUploadFormPath = '/admin/emoji';
-var emojiUploadImagePath = '/customize/emoji';
+var emojiAddEndpoint = '/api/emoji.add';
+var apiTokenRegex = new RegExp('api_token: "(.*)"');
+
+// required to avoid "This browser is not supported" message
+var headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36'};
 
 /**
  * Initialize a new `Slack`.
@@ -46,7 +49,6 @@ function Slack(opts, debug) {
       console.log('Got tokens');
       yield this.login();
       console.log('Logged in');
-      yield this.emoji();
     } catch (e) {
       console.log('Uh oh! ' + e);
       throw e;
@@ -81,12 +83,14 @@ function Slack(opts, debug) {
     opts.jar = opts.jar || { _jar: { store: { idx: {} } } };
     var load = {
       url: opts.url + loginFormPath,
+      headers: headers,
       jar: opts.jar,
       method: 'GET'
     };
     var res = yield request(load);
     var $ = cheerio.load(res[0].body);
     if (this.debug) write($('title').text(), $.html());
+    if (this.debug) fs.writeFileSync('debug/login_page_response.html', res);
     opts.formData = {
       signin: $('#signin_form input[name="signin"]').attr('value'),
       redir: $('#signin_form input[name="redir"]').attr('value'),
@@ -107,12 +111,17 @@ function Slack(opts, debug) {
     var opts = this.opts;
     var load = {
       url: opts.url + loginFormPath,
+      headers: headers,
       jar: opts.jar,
       method: 'POST',
       followAllRedirects: true,
       formData: opts.formData
     };
     var res = yield request(load);
+    if (this.debug) fs.writeFileSync('debug/logged_in_page_response.html', res);
+    if(res[0].body.indexOf("Sorry, you entered an incorrect email address or password.") != -1){
+      throw new Error('Login error: incorrect username / password');
+    }
 
     if(res[0].body.indexOf("Enter your authentication code") != -1){
 
@@ -134,32 +143,22 @@ function Slack(opts, debug) {
 
       var load_2fa = {
         url: opts.url + "/",
+        headers: headers,
         jar: opts.jar,
         method: 'POST',
         followAllRedirects: true,
         formData: formData
       };
-      var res = yield request(load_2fa);
+      res = yield request(load_2fa);
     }
-    return this.opts = opts;
-  };
 
-  /**
-   * Get the emoji upload page.
-   */
+    //TODO: it may be necessary in the future to replace this with a user-supplied token
+    var match = apiTokenRegex.exec(res[0].body);
+    if (!match || !match[1]) {
+      throw new Error('Application Error: unable to find api token on login page');
+    }
+    opts.apiToken = match[1];
 
-  this.emoji = function *() {
-    var opts = this.opts;
-    var load = {
-      url: opts.url + emojiUploadFormPath,
-      jar: opts.jar,
-      method: 'GET'
-    };
-    var res = yield request(load);
-    var $ = cheerio.load(res[0].body);
-    if (this.debug) write($('title').text(), $.html());
-    opts.uploadCrumb = $('input[name="crumb"]').attr('value');
-    if (!opts.uploadCrumb) throw new Error('Login error: could not get emoji upload crumb for ' + opts.url);
     return this.opts = opts;
   };
 
@@ -172,20 +171,21 @@ function Slack(opts, debug) {
     return new Promise(function(resolve, reject, notify) {
       var opts = this.opts;
       var r = req({
-        url: opts.url + emojiUploadImagePath,
+        url: opts.url + emojiAddEndpoint,
+        headers: headers,
         method: 'POST',
         jar: opts.jar,
         followAllRedirects: true
       }, function(err, res, body) {
+        if (this.debug) fs.writeFileSync('debug/emoji_upload_response.html', body);
         if (err || !body) return reject(err);
         resolve(body);
       });
       var form = r.form();
-      form.append('add', '1');
-      form.append('crumb', opts.uploadCrumb);
       form.append('name', name);
       form.append('mode', 'data');
-      form.append('img', req(emoji));
+      form.append('image', req(emoji));
+      form.append('token', opts.apiToken);
     }.bind(this));
   };
 
@@ -194,7 +194,8 @@ function Slack(opts, debug) {
     return new Promise(function(resolve, reject, notify) {
       var opts = this.opts;
       var r = req({
-        url: opts.url + emojiUploadImagePath,
+        url: opts.url + emojiAddEndpoint,
+      headers: {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36'},
         method: 'POST',
         jar: opts.jar,
         followAllRedirects: true
@@ -203,11 +204,10 @@ function Slack(opts, debug) {
         resolve(body);
       });
       var form = r.form();
-      form.append('add', '1');
-      form.append('crumb', opts.uploadCrumb);
       form.append('name', alias);
       form.append('mode', 'alias');
       form.append('alias', name);
+      form.append('token', opts.apiToken);
     }.bind(this));
   };
 }

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -158,7 +158,7 @@ function Slack(opts, debug) {
     var res = yield request(load);
     var $ = cheerio.load(res[0].body);
     if (this.debug) write($('title').text(), $.html());
-    opts.uploadCrumb = $('#addemoji > input[name="crumb"]').attr('value');
+    opts.uploadCrumb = $('input[name="crumb"]').attr('value');
     if (!opts.uploadCrumb) throw new Error('Login error: could not get emoji upload crumb for ' + opts.url);
     return this.opts = opts;
   };

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -90,7 +90,6 @@ function Slack(opts, debug) {
     var res = yield request(load);
     var $ = cheerio.load(res[0].body);
     if (this.debug) write($('title').text(), $.html());
-    if (this.debug) fs.writeFileSync('debug/login_page_response.html', res);
     opts.formData = {
       signin: $('#signin_form input[name="signin"]').attr('value'),
       redir: $('#signin_form input[name="redir"]').attr('value'),
@@ -118,7 +117,6 @@ function Slack(opts, debug) {
       formData: opts.formData
     };
     var res = yield request(load);
-    if (this.debug) fs.writeFileSync('debug/logged_in_page_response.html', res);
     if(res[0].body.indexOf("Sorry, you entered an incorrect email address or password.") != -1){
       throw new Error('Login error: incorrect username / password');
     }
@@ -177,7 +175,6 @@ function Slack(opts, debug) {
         jar: opts.jar,
         followAllRedirects: true
       }, function(err, res, body) {
-        if (this.debug) fs.writeFileSync('debug/emoji_upload_response.html', body);
         if (err || !body) return reject(err);
         resolve(body);
       });


### PR DESCRIPTION
**edit 2** This PR is fixed up and works again hooray
**edit** ~~~There seems to be more at work here, i think something about the auth has changed 😞 
In fact I think the issue is that the "add an emoji button" and therefore the emoji upload crumb is added via JS, meaning requests + cheerio isn't going to cut it.~~~

* The emoji customize page has had another rewrite that removes the
segmentation from the top "addemoji" section and the bottom "emojilist"
section.

* With this upstream change, the existing code would always throw a login error:
```sh
Starting import
Got tokens
Logged in
Uh oh! Error: Login error: could not get emoji upload crumb for https://<ORG>.slack.com
(node:4781) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: Login error: could not get emoji upload crumb for https://<ORG>.slack.com
^C
```

* Simply updating the selector to not require the existance of an
"addemoji" section is enough to allow uploads to continue

There don't appear to be any integration tests that would have caught this. I might look into making something like that possible.