### PR TITLE
Quote strings made by convert-to-emojipack

### DIFF
--- a/bin/convert-to-emojipack
+++ b/bin/convert-to-emojipack
@@ -67,13 +67,13 @@ co(function *() {
     Object.keys(compiledEmojis).forEach((name) => {
       var emoji = compiledEmojis[name];
 
-      stream.write(`  - name: ${emoji.name}\n`);
+      stream.write(`  - name: "${emoji.name}"\n`);
 
       // Write the aliases array if any exist
       if (emoji.aliases && emoji.aliases.length > 0) {
         stream.write('    aliases:\n');
         emoji.aliases.forEach((alias) => {
-          stream.write(`      - ${alias}\n`);
+          stream.write(`      - "${alias}"\n`);
         });
       }
 


### PR DESCRIPTION
* We have some weird emoji, for example :-: and :null:.
<img width="96" alt="screen shot 2018-08-24 at 3 40 03 pm" src="https://user-images.githubusercontent.com/6370918/44607188-2a930f00-a7b5-11e8-908f-17339d3fa29f.png">

* This confuses yaml parsers immensely, and the easy solution is just to
quote strings that are reserve words for node or yaml.
```sh
Uploading n with https://emoji.slack-edge.com/T3T9KQULR/n/38898911c5291054.png
Aliasing  to n
(node:15993) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 2): Error: form-data: Arrays
are not supported.
```
* This change quotes all emoji names and aliases when generating an
emoji yaml to avoid those issues

@adambullmer 