### PR TITLE
Fix aliasing function

### DIFF
--- a/lib/slack.js
+++ b/lib/slack.js
@@ -203,7 +203,7 @@ function Slack(opts, debug) {
       var form = r.form();
       form.append('name', alias);
       form.append('mode', 'alias');
-      form.append('alias', name);
+      form.append('alias_for', name);
       form.append('token', opts.apiToken);
     }.bind(this));
   };


### PR DESCRIPTION
All aliasing didn't work today in my environment.
Did Slack change its `emoji.add` endpoint interface?
Finally, replacing `alias` with `alias_for` seems to make it work.